### PR TITLE
Small adjustment in HeaderSection component

### DIFF
--- a/src/components/Section/HeroSection.tsx
+++ b/src/components/Section/HeroSection.tsx
@@ -19,7 +19,7 @@ export default function HeroSection() {
 						</p>
 					</div>
 
-					<div className="flex items-center justify-between gap-4 flex-row mt-6 space-y-4 sm:items-center sm:justify-center sm:flex-row sm:space-y-0 sm:space-x-4 lg:justify-start">
+					<div className="flex items-center justify-center gap-4 mt-6 space-y-4 sm:space-y-0 sm:space-x-4 lg:justify-start">
 						<button
 							onClick={() => {
 								window.scrollBy(0, 2750)


### PR DESCRIPTION
Using `justify-center` for button container in HeroSection component and removing unnecessary attributes (e.g., `flex` is `flex-row` by default, no need to specify again; also using `sm:item-center` is unnecessary if it's `item-center` for all screen sizes already)